### PR TITLE
Modified how slice order is handled in PAR files to fix problems with…

### DIFF
--- a/dicm2nii.m
+++ b/dicm2nii.m
@@ -847,7 +847,17 @@ for i = 1:nRun
             end
         end
         % fix weird slice ordering for PAR and multiframe
-        if isfield(s, 'SliceNumber'), img(:,:,s.SliceNumber,:) = img; end
+        if isfield(s, 'SliceNumber'), 
+          switch(length(s.SliceNumber))
+            case size(img,3)
+              img(:,:,s.SliceNumber,:) = img; 
+            case size(img,3) * size(img,4)
+              dim = size(img);
+              img = reshape(img,[dim(1:2), dim(3)*dim(4)]);
+              img(:,:,s.SliceNumber) = img; 
+              img = reshape(img,dim);
+          end
+        end
     end
 
     dim = size(img);


### PR DESCRIPTION
… files in which slices and volumes are intermixed

dicm_hdr.m: creates a slice order vector across all volumes instead of assuming that the same order is used for all slices and that volumes (dynamics) are in ascending order. For function scans, the dynamic number and image type (magnitude or phase) is used
 to reorder. For diffusion images, the b value and diffusion orientation number is used. Note that the SliceOrder field is now created for all PAR/dicom header conversion, even if all slices and volumes are in ascending order (in which case the slice order does not change)
dicm2nii.m: how the slice order vector is applied depends on whether is it si as long as the total number of slices (PAR) or the number of slices in a one volume.