### PR TITLE
added additional check for TMPDIR environment variable

### DIFF
--- a/nii_tool.m
+++ b/nii_tool.m
@@ -883,7 +883,10 @@ if isempty(cmd)
         if isempty(pth), pth = pwd; end
     else
         pth = getenv('TMP');
-        if isempty(pth), pth = '/tmp'; end
+        if isempty(pth)
+            pth = getenv('TMPDIR');
+        end
+        if isempty(pth), pth = '/tmp'; end % last resort
     end
     uid = @()sprintf('_%s_%03x', datestr(now, 'yymmddHHMMSSfff'), randi(999));
 end


### PR DESCRIPTION
On some systems TMP returns empty, and on others it is more useful to check TMPDIR. I have added this in the unzipping section. Reasoning: I use nii_tool on a shared cluster environment, and sometimes the default $TMPDIR location (/tmp) can fill up from many users running simultaneously. Therefore I find it better to set my $TMPDIR path to another location on login (in .bashrc) so that I don't have to worry about it running out of space. My proposed change just check this environment variable and respects the user's configuration of that variable if it is something other than the default. 