### PR TITLE
Catch preview

### DIFF
--- a/dicm2nii.m
+++ b/dicm2nii.m
@@ -864,8 +864,13 @@ if bids
         Subject = {'01'};
     end
     Session                = {'01'};
-    AcquisitionDate        = datetime(acq{1},'InputFormat','yyyyMMdd');
-    AcquisitionDate.Format = 'yyyy-MM-dd';
+    if verLessThanOctave
+        AcquisitionDate        = acq{1};
+        AcquisitionDate        = [AcquisitionDate(1:4) '-' AcquisitionDate(5:6) '-' AcquisitionDate(7:8)];
+    else
+        AcquisitionDate        = datetime(acq{1},'InputFormat','yyyyMMdd');
+        AcquisitionDate.Format = 'yyyy-MM-dd';
+    end
     Comment                = {'N/A'};
     S = table(Subject,Session,AcquisitionDate,Comment);
     
@@ -927,7 +932,6 @@ if bids
     if verLessThanOctave
         SCN = S.Properties.VariableNames;
         S   = table2cell(S); 
-        S{3}= datestr(S{3},'yyyy-mm-dd');
         TCN = T.Properties.VariableNames;
         T   = cellfun(@char,table2cell(T),'uni',0);
     end
@@ -1035,8 +1039,8 @@ for i = 1:nRun
         % _session.tsv
         try
             tsvfile = fullfile(niiFolder, ['sub-' char(SubjectTable{1,1})],['sub-' char(SubjectTable{1,1}) '_sessions.tsv']);
-                write_tsv(session_id,tsvfile,'acq_time',datestr(SubjectTable{3},'yyyy-mm-dd'),'Comment',SubjectTable{4})
             if verLessThanOctave
+                write_tsv(session_id,tsvfile,'acq_time',SubjectTable{3},'Comment',SubjectTable{4})
             else
                 write_tsv(session_id,tsvfile,'acq_time',datestr(SubjectTable.AcquisitionDate,'yyyy-mm-dd'),'Comment',SubjectTable.Comment)
             end

--- a/dicm2nii.m
+++ b/dicm2nii.m
@@ -3178,6 +3178,7 @@ switch selection
 end
 
 function previewDicom(ax,s)
+try
 nSL = double(tryGetField(s{1}, 'LocationsInAcquisition'));
 if isempty(nSL)
     nSL = length(s);
@@ -3190,9 +3191,14 @@ if verLessThan('matlab','9.4')
     ax.YTickLabel = [];
     ax.XTickLabel = [];
 else
-    imagesc(ax,dicm_img(s{round(nSL/2)}));
+    img = dicm_img(s{min(end,round(nSL/2))});
+    img = img(:,:,:,round(end/2));
+    imagesc(ax,img);
 end
-ax.DataAspectRatio = [s{round(nSL/2)}.PixelSpacing' 1];
+ax.DataAspectRatio = [s{min(end,round(nSL/2))}.PixelSpacing' 1];
+catch err
+    warning(['CANNOT PREVIEW RUN: ' err.message])
+end
 
 function showHelp(valueset)
 %%

--- a/dicm2nii.m
+++ b/dicm2nii.m
@@ -411,7 +411,7 @@ if ischar(fmt) && strcmpi(fmt,'BIDSNII')
     bids = true;
     fmt = '.nii';
 end
-if bids && verLessThan('matlab','9.4')
+if bids && verLessThanOctave
     fprintf('BIDS conversion is easier with MATLAB R2018a or more.\n')
 end
 
@@ -911,7 +911,7 @@ if bids
     figargs = {'bids' * 256.^(0:3)','Position',[min(scrSz(4)+420,620) scrSz(4)-600 420 300],...
                'Color', clr,...
                'CloseRequestFcn',@my_closereq};
-    if verLessThan('matlab','9.4')
+    if verLessThanOctave
         hf = figure(figargs{1});
         set(hf,figargs{2:end});
         % add help
@@ -924,7 +924,7 @@ if bids
     set(hf,'Name', 'dicm2nii - BIDS Converter', 'NumberTitle', 'off')
 
     % tables
-    if verLessThan('matlab','9.4')
+    if verLessThanOctave
         SCN = S.Properties.VariableNames;
         S   = table2cell(S); 
         S{3}= datestr(S{3},'yyyy-mm-dd');
@@ -935,7 +935,7 @@ if bids
     TT = uitable(hf,'Data',T);
     TSpos = [20 hf.Position(4)-110 hf.Position(3)-160 90];
     TTpos = [20 20 hf.Position(3)-160 hf.Position(4)-120];
-    if verLessThan('matlab','9.4')
+    if verLessThanOctave
         setpixelposition(TS,TSpos);
         set(TS,'Units','Normalized')
         setpixelposition(TT,TTpos);
@@ -945,7 +945,7 @@ if bids
         TT.Position = TTpos;
     end
     TS.ColumnEditable = [true true true true];
-    if verLessThan('matlab','9.4')
+    if verLessThanOctave
         TS.ColumnName = SCN;
         TT.ColumnName = TCN;
     end
@@ -956,7 +956,7 @@ if bids
     % button
    	Bpos = [hf.Position(3)-120 20 100 30];
     BCB  = @(btn,event) BtnModalityTable(hf,TT, TS);
-    if verLessThan('matlab','9.4')
+    if verLessThanOctave
         B = uicontrol(hf,'Style','pushbutton','String','OK');
         set(B,'Callback',BCB);
         setpixelposition(B,Bpos)
@@ -1035,8 +1035,8 @@ for i = 1:nRun
         % _session.tsv
         try
             tsvfile = fullfile(niiFolder, ['sub-' char(SubjectTable{1,1})],['sub-' char(SubjectTable{1,1}) '_sessions.tsv']);
-            if verLessThan('matlab','9.4')
                 write_tsv(session_id,tsvfile,'acq_time',datestr(SubjectTable{3},'yyyy-mm-dd'),'Comment',SubjectTable{4})
+            if verLessThanOctave
             else
                 write_tsv(session_id,tsvfile,'acq_time',datestr(SubjectTable.AcquisitionDate,'yyyy-mm-dd'),'Comment',SubjectTable.Comment)
             end
@@ -2046,7 +2046,7 @@ switch cmd
         end
         rstFmt = (get(hs.rstFmt, 'Value') - 1) * 2; % 0 or 2
         if rstFmt == 4
-            if verLessThan('matlab','9.4')
+            if verLessThanOctave
                 fprintf('BIDS conversion is easier with MATLAB R2018a or more.\n');
             end
             if get(hs.gzip,  'Value')
@@ -3147,7 +3147,7 @@ v = bsxfun(@rdivide, M, den);
 %%
 
 function BtnModalityTable(h,TT,TS)
-if verLessThan('matlab','9.4')
+if verLessThanOctave
     dat = TT.Data;
 else
     dat = cellfun(@char,table2cell(TT.Data),'uni',0);
@@ -3163,7 +3163,7 @@ delete(h)
 function my_closereq(src,~)
 % Close request function 
 % to display a question dialog box
-if verLessThan('matlab','9.4')
+if verLessThanOctave
     selection = questdlg('Cancel Dicom conversion?','Close dicm2nii','OK','Cancel','Cancel');
 else
     selection = uiconfirm(src,'Cancel Dicom conversion?',...
@@ -3231,3 +3231,7 @@ h = msgbox(msg,'Help on BIDS converter');
 set(findall(h,'Type','Text'),'FontName','FixedWidth');
 Pos = get(h,'Position'); Pos(3) = 450;
 set(h,'Position',Pos)
+
+function val = verLessThanOctave
+isOctave = exist('OCTAVE_VERSION', 'builtin') ~= 0;
+val = isOctave || verLessThan('matlab','9.4');

--- a/write_tsv.m
+++ b/write_tsv.m
@@ -14,7 +14,7 @@ if exist(tsvfile,'file') % read already existing tsvfile
     % Number of columns
     fid = fopen(tsvfile);
     tline = fgetl(fid);
-    fclose(fid)
+    fclose(fid);
     Nvar = sum(~cellfun(@isempty,strsplit(tline,'\t')));
     % read tsv file
     T = readtable(tsvfile,'FileType','text','Delimiter','\t','Format',repmat('%s',[1,Nvar]));


### PR DESCRIPTION
@xiangruili this PR improves robustness of the BIDS conversion by incorporating a try/catch in the BIDS preview b046b66 and 2eb8d8c
Also I removed dependency with datetime for old MATLAB versions
And finally made it compatible with Octave 5.1 beta3
Best,
Tanguy