### PR TITLE
remove warnings when adding to table col by col

### DIFF
--- a/write_tsv.m
+++ b/write_tsv.m
@@ -22,6 +22,7 @@ end
 varargin(1:2:end) = cellfun(@genvarname,varargin(1:2:end),'uni',0);
 varargin(cellfun(@isempty,varargin)) = {'N/A'};
 if exist(tsvfile,'file') && ~isempty(T) % append to already existing tsvfile
+    warning('OFF', 'MATLAB:table:RowsAddedExistingVars');
     ind = find(strcmp(table2cell(T(:,1)),id),1);
     if isempty(ind)
         ind = size(T,1)+1;
@@ -54,5 +55,6 @@ else % write new tsvfile
         idName = inputname(1);
     end
     T.Properties.VariableNames = {idName varargin{1:2:end}};
+    warning('ON', 'MATLAB:table:RowsAddedExistingVars');
 end
 writetable(T,tsvfile,'Delimiter','\t','FileType','text')


### PR DESCRIPTION
The matlab warning: "Warning: The assignment added rows to the table, but did not assign values to all of the table's existing variables. Those variables are extended with rows containing default values. " when adding to the partcipants.tsv are annoying and could cause concern among users who are uncertain what it means. Matlab seems to prefer building tables an entire row at a time but given that write_tsv.m needs to keep an eye out for new columns (and then nan those for the previous subjects) it seems best to keep it as is and build col by col. I think it's pretty safe to disable the warning during this process. What do you think? 